### PR TITLE
Update FollowLink.php

### DIFF
--- a/src/FollowLink.php
+++ b/src/FollowLink.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\follow;
 
-require_once 'modules/contrib/follow/follow.inc';
+require_once __DIR__.'/../follow.inc';
 
 /**
  * Handles CRUD operations to {follow_links} table.


### PR DESCRIPTION
To avoid : PHP  Fatal error:  require_once(): Failed opening required 'modules/contrib/follow/follow.inc' 
in the case the module is stored somewhere else (not in contrib)